### PR TITLE
FG-1/Fixing bug where Riolu is in two eggs

### DIFF
--- a/src/components/Pokemon.js
+++ b/src/components/Pokemon.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import "./Pokemon.css";
+import { isArray } from "util";
 
 class Pokemon extends Component {
   render() {
@@ -55,14 +56,27 @@ class Pokemon extends Component {
             <div className="pokemon__info__title">Max CP</div>
             <div className="pokemon__info__value">{data.maxCP}</div>
           </div>
-          {data.egg && data.egg !== "Not in Eggs" && (
+          {data.egg && data.egg !== "Not in Eggs" && isArray(data.egg) ? (
             <div className="pokemon__info__egg-type">
-              <img
-                className="pokemon__info__egg"
-                src={`/images/eggs/${data.egg}.png`}
-                alt={`${data.egg} egg`}
-              />
+              {data.egg.map(egg => (
+                <img
+                  className="pokemon__info__egg"
+                  src={`/images/eggs/${egg}.png`}
+                  alt={`${egg} egg`}
+                />
+              ))}
             </div>
+          ) : (
+            data.egg &&
+            data.egg !== "Not in Eggs" && (
+              <div className="pokemon__info__egg-type">
+                <img
+                  className="pokemon__info__egg"
+                  src={`/images/eggs/${data.egg}.png`}
+                  alt={`${data.egg} egg`}
+                />
+              </div>
+            )
           )}
         </div>
       </div>

--- a/src/data/eggs.json
+++ b/src/data/eggs.json
@@ -1889,7 +1889,7 @@
   },
   {
     "name": "Riolu",
-    "inEggs": "10km7km"
+    "inEggs": ["7km", "10km"]
   },
   {
     "name": "Lucario",


### PR DESCRIPTION
Riolu appears in both 7km and 10km for some reason.

I wasn't accounting for this. I've had to do some manual manipulation of the data in the eggs.json file. I'll need to put something in place that does this automatically going forward.

Note to self: Maybe store all eggs in an array. Then it wouldn't matter and we could check against the length of the array before displaying them.